### PR TITLE
Fix inefficient lazy imread and imsave

### DIFF
--- a/impy/__init__.py
+++ b/impy/__init__.py
@@ -1,19 +1,19 @@
-__version__ = "2.3.3"
+__version__ = "2.4.0"
 __author__ = "Hanjin Liu"
 __email__ = "liuhanjin-sc@g.ecc.u-tokyo.ac.jp"
 
 import logging
 
-from ._const import Const, SetConst, use
+from ._const import Const, SetConst, use  # noqa
 
-from .collections import DataList, DataDict
-from .core import *
-from .binder import bind
-from .viewer import gui
-from .correlation import *
-from .arrays import ImgArray, LazyImgArray, BigImgArray, Label  # for typing
-from . import random, io, lazy
-from .axes import slicer
+from .collections import DataList, DataDict  # noqa
+from .core import *  # noqa
+from .binder import bind  # noqa
+from .viewer import gui  # noqa
+from .correlation import *  # noqa
+from .arrays import ImgArray, LazyImgArray, BigImgArray, Label  # noqa
+from . import random, io, lazy  # noqa
+from .axes import slicer  # noqa
 
 # Inheritance
 # -----------
@@ -34,7 +34,7 @@ logging.getLogger("tifffile").setLevel(logging.ERROR)
 del logging
 
 # dtypes
-from numpy import (
+from numpy import (  # noqa
     uint8, uint16, uint32, uint64,
     int8, int16, int32, int64,
     float16, float32, float64,

--- a/impy/arrays/_utils/_deconv.py
+++ b/impy/arrays/_utils/_deconv.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 from functools import partial
 import numpy as np
 from impy.array_api import xp
 
-if TYPE_CHECKING:
-    from impy.arrays import ImgArray
-    
 try:
     gradient = xp.gradient
 except AttributeError:
@@ -17,18 +13,18 @@ except AttributeError:
         out = numpy.gradient(a.get(), axis=axis)
         return xp.asarray(out)
 
-__all__ = ["wiener", "lucy", "lucy_tv", "check_psf"]
+__all__ = ["wiener", "richardson_lucy", "richardson_lucy_tv", "check_psf"]
 
 def wiener(obs, psf_ft, psf_ft_conj, lmd):
     obs = xp.asarray(obs)
     fft = xp.fft.rfftn
     ifft = partial(xp.fft.irfftn, s=obs.shape)
-    
+
     img_ft = fft(obs)
-    
+
     estimated = xp.real(ifft(img_ft*psf_ft_conj / (psf_ft*psf_ft_conj + lmd)))
     return xp.fft.fftshift(estimated)
-    
+
 def richardson_lucy(obs, psf_ft, psf_ft_conj, niter, eps):
     # Identical to the algorithm in Deconvolution.jl of Julia.
     obs = xp.asarray(obs)
@@ -36,12 +32,12 @@ def richardson_lucy(obs, psf_ft, psf_ft_conj, niter, eps):
     ifft = partial(xp.fft.irfftn, s=obs.shape)
     conv = factor = xp.empty(obs.shape, dtype=xp.float32) # placeholder
     estimated = xp.real(ifft(fft(obs) * psf_ft))   # initialization
-    
+
     for _ in range(niter):
         conv[:] = ifft(fft(estimated) * psf_ft).real
         factor[:] = ifft(fft(_safe_div(obs, conv, eps=eps)) * psf_ft_conj).real
         estimated *= factor
-        
+
     return xp.fft.fftshift(estimated)
 
 def richardson_lucy_tv(obs, psf_ft, psf_ft_conj, max_iter, lmd, tol, eps):
@@ -51,21 +47,21 @@ def richardson_lucy_tv(obs, psf_ft, psf_ft_conj, max_iter, lmd, tol, eps):
     est_old = ifft(fft(obs) * psf_ft).real
     est_new = xp.empty(obs.shape, dtype=xp.float32)
     conv = factor = norm = gg = xp.empty(obs.shape, dtype=np.float32) # placeholder
-    
+
     for _ in range(max_iter):
         conv[:] = ifft(fft(est_old) * psf_ft).real
         factor[:] = ifft(fft(_safe_div(obs, conv, eps=eps)) * psf_ft_conj).real
         est_new[:] = est_old * factor
         grad = gradient(est_old)
         norm[:] = xp.sqrt(sum(g**2 for g in grad))
-        gg[:] = sum(gradient(_safe_div(grad[i], norm, eps=1e-8), axis=i) 
+        gg[:] = sum(gradient(_safe_div(grad[i], norm, eps=1e-8), axis=i)
                     for i in range(obs.ndim))
         est_new /= (1 - lmd * gg)
         gain = xp.sum(xp.abs(est_new - est_old))/xp.sum(xp.abs(est_old))
         if gain < tol:
             break
         est_old[:] = est_new
-        
+
     return xp.fft.fftshift(est_new)
 
 
@@ -81,7 +77,7 @@ def check_psf(img_shape: tuple[int, ...], img_scale: tuple[float, ...], psf):
         psf = psf(img_shape, img_scale)
     psf = xp.asarray(psf, dtype=np.float32)
     psf /= xp.sum(psf)
-    
+
     if img_shape != psf.shape:
         raise ValueError(
             f"observation and PSF have different shape: {img_shape} and {psf.shape}"

--- a/impy/arrays/_utils/_filters.py
+++ b/impy/arrays/_utils/_filters.py
@@ -6,7 +6,7 @@ from scipy import ndimage as scipy_ndi
 
 
 __all__ = ["binary_erosion",
-    "erosion"
+    "erosion",
     "binary_dilation",
     "dilation",
     "binary_opening",

--- a/impy/arrays/_utils/_glcm.py
+++ b/impy/arrays/_utils/_glcm.py
@@ -1,6 +1,6 @@
 import numpy as np
-from ...collections import DataDict
 import scipy
+from impy.collections import DataDict
 
 __all__ = ["glcm_props_", "check_glcm"]
 
@@ -15,7 +15,7 @@ def asm_(glcm, ref, nei):
 
 def idm_(glcm, ref, nei):
     return np.sum(glcm/(1+(ref-nei)**2), axis=(0,1))
-    
+
 def energy_(glcm, ref, nei):
     return np.sqrt(np.sum(glcm**2, axis=(0,1)))
 
@@ -29,11 +29,11 @@ def entropy_(glcm, ref, nei):
 def correlation_(glcm, ref, nei):
     diffy = ref - np.sum(glcm * ref, axis=(0,1))
     diffx = nei - np.sum(glcm * nei, axis=(0,1))
-    
+
     stdy = np.sqrt(np.sum(glcm*diffy**2, axis=(0,1)))
     stdx = np.sqrt(np.sum(glcm*diffx**2, axis=(0,1)))
     cov = np.sum(glcm*diffx*diffy, axis=(0,1))
-    
+
     out = np.empty(glcm.shape[2:], dtype=np.float32)
     mask_0 = np.logical_or(stdx<1e-15, stdy<1e-15)
     mask_1 = ~mask_0
@@ -73,7 +73,7 @@ propdict = {"contrast": contrast_,
 def glcm_props_(data, distances, angles, levels, radius, properties):
     outshape = (len(distances), len(angles)) + \
         (data.shape[0]-2*radius, data.shape[1]-2*radius)
-        
+
     propout = DataDict()
     for prop in properties:
         if isinstance(prop, str):
@@ -82,13 +82,13 @@ def glcm_props_(data, distances, angles, levels, radius, properties):
             propout[prop.__name__] = np.empty(outshape, dtype=np.float32)
     # placeholder
     glcm = np.empty((levels, levels, len(distances), len(angles)), dtype=np.float32)
-    
+
     ref, nei = np.indices((levels, levels), dtype=np.float32)
     ref = ref[:, :, np.newaxis, np.newaxis]
     nei = nei[:, :, np.newaxis, np.newaxis]
-    
+
     from ._process_numba import _calc_glcm
-    
+
     for x in range(outshape[3]):
         for y in range(outshape[2]):
             # calc glcm
@@ -101,7 +101,7 @@ def glcm_props_(data, distances, angles, levels, radius, properties):
                 else:
                     # only callable
                     propout[prop.__name__][:,:,y,x] = prop(glcm, ref, nei)
-    
+
     return propout
 
 def check_glcm(self, bins, rescale_max):
@@ -112,22 +112,22 @@ def check_glcm(self, bins, rescale_max):
             bins = 256
     elif bins > 256:
         raise ValueError("`bins` must be smaller than 256.")
-    
+
     if self.dtype == np.uint16:
         self = self.as_uint8()
     elif self.dtype == np.uint8:
         pass
     else:
         raise TypeError(f"Cannot calculate comatrix of {self.dtype} image.")
-        
+
     imax = np.iinfo(self.dtype).max
-    
+
     if rescale_max:
         scale = int(imax/self.max())
         self *= scale
-    
+
     if (imax+1) % bins != 0 or bins > imax+1:
         raise ValueError(f"`bins` must be a divisor of {imax+1} (max value of {self.dtype}).")
     self = self // ((imax+1) // bins)
-    
+
     return self, bins, rescale_max

--- a/impy/arrays/_utils/_misc.py
+++ b/impy/arrays/_utils/_misc.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import numpy as np
-from ...array_api import xp
+from impy.array_api import xp
 
 def adjust_bin(
     img: np.ndarray,
@@ -44,12 +44,12 @@ def make_rotated_axis(src, dst):
 def make_pad(pad_width, dims, all_axes, **kwargs):
     """More flexible padding than `np.pad`."""
     pad_width_ = []
-        
+
     # for consistency with scipy-format
     if "cval" in kwargs.keys():
         kwargs["constant_values"] = kwargs["cval"]
         kwargs.pop("cval")
-        
+
     if hasattr(pad_width, "__iter__") and len(pad_width) == len(dims):
         pad_iter = iter(pad_width)
         for a in all_axes:
@@ -57,7 +57,7 @@ def make_pad(pad_width, dims, all_axes, **kwargs):
                 pad_width_.append(next(pad_iter))
             else:
                 pad_width_.append((0, 0))
-        
+
     elif isinstance(pad_width, int):
         for a in all_axes:
             if a in dims:
@@ -66,7 +66,7 @@ def make_pad(pad_width, dims, all_axes, **kwargs):
                 pad_width_.append((0, 0))
     else:
         raise TypeError(f"pad_width must be iterable or int, but got {type(pad_width)}")
-    
+
     return pad_width_
 
 def dft(img: xp.ndarray, exps: list[xp.ndarray] = None):

--- a/impy/arrays/_utils/_structures.py
+++ b/impy/arrays/_utils/_structures.py
@@ -1,5 +1,5 @@
 import numpy as np
-from ...array_api import xp
+from impy.array_api import xp
 
 def circle(radius, shape, dtype="bool"):
     x = xp.arange(-(shape[0] - 1) / 2, (shape[0] - 1) / 2 + 1)
@@ -10,7 +10,7 @@ def circle(radius, shape, dtype="bool"):
 def ball_like(radius, ndim:int):
     half_int = int(2*radius)/2
     L = xp.arange(-half_int, half_int + 1)
-    
+
     if ndim == 1:
         return xp.ones(int(radius)*2+1, dtype=np.uint8)
     elif ndim == 2:
@@ -32,7 +32,7 @@ def ball_like_odd(radius, ndim):
      [1, 1, 1, 1],
      [0, 1, 1, 0]]
     This is not suitable for specify().
-    """    
+    """
     xc = int(radius)
     l = xc*2 + 1
     coords = xp.indices((l,)*ndim)

--- a/impy/io.py
+++ b/impy/io.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
     from .arrays.bases import MetaArray
     from .arrays import LazyImgArray
     from .axes import Axes
+    from dask.array.core import Array
 
     ImpyArray = Union[MetaArray, LazyImgArray]
     Reader = Callable[[str, bool], ImageData]
@@ -369,7 +370,9 @@ def _(path: str, img: ImpyArray, lazy: bool = False):
         from dask import array as da
         kwargs = _get_ijmeta_from_img(img, update_lut=False)
         mmap = memmap(str(path), shape=img.shape, dtype=img.dtype, **kwargs)
-        da.store(img.value, mmap, compute=True)
+        img_dask = _rechunk_to_ones(img.value)
+        writer = _MemmapArrayWriter(path, mmap.offset, img.shape, img_dask.chunksize)
+        da.store(img_dask, writer)
         mmap.flush()
         return
 
@@ -392,7 +395,7 @@ def _(path: str, img: ImpyArray, lazy: bool = False):
         img_new.set_scale(img)
         img = img_new
 
-        warnings.warn("Image axes changed", UserWarning)
+        warnings.warn("Image axes changed", UserWarning, stacklevel=2)
 
     img = img.sort_axes()
     if img.dtype == "bool":
@@ -464,7 +467,10 @@ def _(path: str, img: ImpyArray, lazy: bool = False):
         mode = _MRC_MODE[img.dtype]
         mrc_mmap = mrcfile.new_mmap(path, img.shape, mrc_mode=mode, overwrite=True)
         mrc_mmap.voxel_size = voxel_size
-        da.store(img.value, mrc_mmap.data)
+
+        img_dask = _rechunk_to_ones(img.value)
+        writer = _MemmapArrayWriter(path, mrc_mmap.data.offset, img.shape, img_dask.chunksize)
+        da.store(img_dask, writer)
         mrc_mmap.flush()
         return None
 
@@ -689,3 +695,56 @@ def _scalar(x: Any) -> np.ndarray:
     ar = np.array(None, dtype=object)
     ar[()] = x
     return ar
+
+def _rechunk_to_ones(arr: Array):
+    """Rechunk the array to (1, 1, ..., 1, n, Ny, Nx)"""
+    size = np.prod(arr.chunksize)
+    shape = arr.shape
+    cur_prod = 1
+    max_i = arr.ndim
+    for i in reversed(range(arr.ndim)):
+        cur_prod *= shape[i]
+        if cur_prod > size:
+            break
+        max_i = i
+    nslices = max(int(size / np.prod(shape[max_i:])), 1)
+    if max_i == 0:
+        return arr
+    else:
+        return arr.rechunk((1,) * (max_i - 1) + (nslices,) + shape[max_i:])
+
+class _MemmapArrayWriter:
+    def __init__(
+        self,
+        path: str,
+        offset: int,
+        shape: tuple[int, ...],
+        chunksize: tuple[int, ...],
+    ):
+        self._path = path
+        self._offset = offset
+        self._shape = shape  # original shape
+        self._chunksize = chunksize  # chunk size
+        # shape = (33, 160, 1000, 1000)
+        # chunksize = (1, 16, 1000, 1000)
+        border = 0
+        for i, c in enumerate(chunksize):
+            if c != 1:
+                border = i
+                break
+        self._border = border
+
+    def __setitem__(self, sl: tuple[slice, ...], arr: np.ndarray):
+        # efficient: shape = (10, 100, 150) and sl = (3:5, 0:100, 0:150)
+        # sl = (0:1, 16:32, 0:1000, 0:1000)
+
+        offset = np.sum([sl[i].start * arr.strides[i] for i in range(self._border + 1)])
+        mmap = np.memmap(
+            self._path,
+            mode="r+",
+            offset=self._offset + offset,
+            dtype=arr.dtype,
+        )
+        arr_ravel = arr.ravel()
+        mmap[:arr_ravel.size] = arr_ravel
+        mmap.flush()

--- a/impy/io.py
+++ b/impy/io.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Any, NamedTuple, Callable, TypeVar, Union, Protocol
+
+from typing import TYPE_CHECKING, Any, NamedTuple, Callable, Sequence, TypeVar, Union, Protocol
+from pathlib import Path
 import json
 import re
 import warnings
@@ -123,7 +125,7 @@ class ImageIO:
 
         return _register
 
-    def imread(self, path: str, memmap: bool = False) -> ImageData:
+    def imread(self, path: str | Path, memmap: bool = False) -> ImageData:
         """
         Read an image file.
 
@@ -141,11 +143,15 @@ class ImageIO:
         ImageData
             Image data tuple.
         """
-        _, ext = os.path.splitext(path)
+        ext = Path(path).suffix
         reader = self._reader.get(ext, self._default_reader)
-        return reader(path, memmap)
+        return reader(str(path), memmap)
 
-    def imread_dask(self, path: str, chunks: Any) -> ImageData:
+    def _imread_slice(self, path, sl: tuple[slice, ...]) -> np.memmap:
+        mmap = self.imread(path, memmap=True).image
+        return np.asarray(mmap[sl], dtype=mmap.dtype)
+
+    def imread_dask(self, path: str | Path, chunks: Any) -> ImageData:
         """
         Read an image file as a dask array.
 
@@ -165,21 +171,39 @@ class ImageIO:
             Image data tuple.
         """
         from .array_api import xp
+
+        path = Path(path)
         image_data = self.imread(path, memmap=True)
         img = image_data.image
 
-        if img.dtype == ">u2":
-            img = img.astype(np.uint16)
+        from dask import array as da, delayed
+        from dask.array.core import normalize_chunks
 
-        from dask import array as da
-        if str(type(img)) == "<class 'zarr.core.Array'>":
+        if path.suffix == ".zarr":
+            if img.dtype == ">u2":
+                img = img.astype(np.uint16)
             dask = da.from_zarr(img, chunks=chunks).map_blocks(
                 xp.asarray, dtype=img.dtype
             )
         else:
-            dask = da.from_array(img, chunks=chunks, meta=xp.array([])).map_blocks(
-                xp.asarray, dtype=img.dtype
+            chunks_: tuple[tuple[int, ...]] = normalize_chunks(
+                chunks,
+                shape=img.shape,
+                dtype=img.dtype,
             )
+            chunk_slices = [_chunk_to_slice(c) for c in chunks_]
+            block_shape = tuple(len(c) for c in chunks_)
+            delayed_imread = delayed(self._imread_slice)
+            arr_blocks = np.empty(block_shape, dtype=object)
+            for ind, _ in np.ndenumerate(arr_blocks):
+                sl = tuple(sls[i] for i, sls in zip(ind, chunk_slices))
+                cur_shape = tuple(_sl.stop - _sl.start for _sl in sl)
+                arr_blocks[ind] = da.from_delayed(
+                    delayed_imread(path, sl), shape=cur_shape, dtype=img.dtype,
+                    meta=xp.array([]),
+                )
+            dask = da.block(arr_blocks.tolist())
+
         return ImageData(
             image=dask,
             axes=image_data.axes,
@@ -199,6 +223,15 @@ class ImageIO:
         writer = self._writer.get(ext, self._default_writer)
         return writer(path, img, lazy)
 
+def _chunk_to_slice(chunk: Sequence[int]) -> list[slice]:
+    # _chunk_to_slice([5, 15, 30]) --> [0:5, 5:20, 20:50]
+    start = 0
+    out: list[slice] = []
+    for c in chunk:
+        _next = start + c
+        out.append(slice(start, _next))
+        start = _next
+    return out
 
 IO = ImageIO()
 

--- a/impy/lazy/__init__.py
+++ b/impy/lazy/__init__.py
@@ -1,2 +1,2 @@
-from .core import *
-from . import random
+from .core import *  # noqa
+from . import random  # noqa


### PR DESCRIPTION
This PR fixes several issues regarding to array IO lazy operations.

- Directly mapping memmap to dask array caused unnecessary computation. This was fixed by constructing memmap for every blocks.
- `da.store` on memmap **does not save memory at all**. Rechunk the original image and properly assign image slices to the memory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Upgraded to version 2.4.0 with enhanced functionality.
	- Introduced `erosion` filter for advanced image processing.
	- Improved image reading capabilities with support for both string and `Path` types.
	- Added new methods for optimized image data handling and memory management.
- **Enhancements**
	- Renamed `lucy` functions to `richardson_lucy` and `lucy_tv` to `richardson_lucy_tv` for clearer naming conventions.
	- Adjusted logic in key functions for more accurate image deconvolution processes.
- **Documentation and Style**
	- Updated import statements and added comments for better code readability.
	- Minor whitespace and formatting adjustments across various modules.
- **Tests**
	- Enhanced testing suite with new tests for lazy image saving and parameterized testing for different file extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->